### PR TITLE
Add group events page to menu

### DIFF
--- a/about.html
+++ b/about.html
@@ -1540,6 +1540,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/bas-elgersma.html
+++ b/bas-elgersma.html
@@ -1132,6 +1132,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/bike-ride-beach-day.html
+++ b/bike-ride-beach-day.html
@@ -1212,6 +1212,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/board-games.html
+++ b/board-games.html
@@ -1296,6 +1296,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/board.html
+++ b/board.html
@@ -1518,6 +1518,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/competitions.html
+++ b/competitions.html
@@ -1834,6 +1834,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/contact.html
+++ b/contact.html
@@ -1761,6 +1761,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/eveline.html
+++ b/eveline.html
@@ -1008,6 +1008,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/founders.html
+++ b/founders.html
@@ -1900,6 +1900,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/group-events.html
+++ b/group-events.html
@@ -1403,6 +1403,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/ice-skating.html
+++ b/ice-skating.html
@@ -1280,6 +1280,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/kayaking-pizza.html
+++ b/kayaking-pizza.html
@@ -1147,6 +1147,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/kingsday-training.html
+++ b/kingsday-training.html
@@ -1352,6 +1352,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/marcos-ross.html
+++ b/marcos-ross.html
@@ -1187,6 +1187,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/moments.html
+++ b/moments.html
@@ -1997,6 +1997,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/movie-night.html
+++ b/movie-night.html
@@ -1499,6 +1499,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/nadja-froitzheim.html
+++ b/nadja-froitzheim.html
@@ -1246,6 +1246,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/practice-prices.html
+++ b/practice-prices.html
@@ -1768,6 +1768,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/rick-linnebank.html
+++ b/rick-linnebank.html
@@ -1126,6 +1126,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/scavenger-hunt.html
+++ b/scavenger-hunt.html
@@ -1574,6 +1574,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/social.html
+++ b/social.html
@@ -1784,6 +1784,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/temp_template.html
+++ b/temp_template.html
@@ -1117,6 +1117,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <div class="dropdown">

--- a/testimonials.html
+++ b/testimonials.html
@@ -1250,6 +1250,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/ties-leider.html
+++ b/ties-leider.html
@@ -1134,6 +1134,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/tuesday-drinks.html
+++ b/tuesday-drinks.html
@@ -1298,6 +1298,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/vincent-van-den-brink.html
+++ b/vincent-van-den-brink.html
@@ -1699,6 +1699,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>

--- a/youth-trainings.html
+++ b/youth-trainings.html
@@ -1402,6 +1402,7 @@
         <div class="dropdown-content">
           <a href="practice-prices.html">Practice & Prices</a>
           <a href="youth-trainings.html">Youth Trainings</a>
+          <a href="group-events.html">Group Events</a>
         </div>
       </div>
       <a href="competitions.html">Competitions</a>


### PR DESCRIPTION
Add 'Group Events' to the 'Trainings' dropdown menu on all website pages for desktop.

---
<a href="https://cursor.com/background-agent?bcId=bc-474aaaaa-4fe9-4b11-be54-75d73dad485a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-474aaaaa-4fe9-4b11-be54-75d73dad485a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

